### PR TITLE
为博客的主题增加站内搜索 Add in-site search for blog topics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,11 @@ favicon: /favicon.png
 # Google Analytics Tracking ID
 google_analytics:
 
+# 全站搜索，需下载hexo-generator-search才可使用
+local_search:
+  enable: false
+  # if auto, trigger search by changing input
+  # if manual, trigger search by pressing enter key or search button
+  trigger: auto
+  # show top n results per article, show all results by setting to -1
+  top_n_per_article: 1

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -8,3 +8,11 @@
     });
   });
 </script>
+<script type="text/javascript">      
+     var search_path = "<%= config.search.path %>";
+     if (search_path.length == 0) {
+     	search_path = "search.xml";
+     }
+     var path = "<%= config.root %>" + search_path;
+     searchFunc(path, 'local-search-input', 'local-search-result');
+</script>

--- a/layout/_partial/html-head.ejs
+++ b/layout/_partial/html-head.ejs
@@ -10,13 +10,15 @@
   <meta property="og:site_name" content="<%= config.title || '' %>"/>
   <meta property="og:type" content="<%= page.title ? 'article' : 'website' %>" />
   <meta property="og:image" content="<%= config.url %><%= config.cover %>"/>
+  <script src="https://cdn.staticfile.org/jquery/1.10.2/jquery.min.js"></script>
   <% if (theme.rss) { %>
     <link rel="alternate" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>
   <% if (theme.favicon) { %>
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
-
+  
+  <script type="text/javascript" charset="utf-8" async="" src="/js/search.js"></script>
   <!-- Site Title -->
   <title><%- config.title %></title>
 

--- a/layout/_partial/website-search.ejs
+++ b/layout/_partial/website-search.ejs
@@ -1,0 +1,6 @@
+<% if (theme.local_search.enable){ %>
+    <div id="site_search">
+      <input type="text" id="local-search-input" name="q" results="0" placeholder="search my blog..." class="form-control"/>
+      <div id="local-search-result"></div>
+    </div>
+<% } %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -1,6 +1,7 @@
 <%- partial('_partial/header', {headerType: 'index'}) %>
 <!-- Home Page Post List -->
 <div class="container">
+  <%- partial('_partial/website-search') %>
   <div class="row">
     <div class="col-lg-10 col-md-10 col-md-offset-1">
       <% page.posts.each(function(post){ %>

--- a/source/css/_partial/index-entry.styl
+++ b/source/css/_partial/index-entry.styl
@@ -53,6 +53,9 @@
       border-radius remify(3px)
     .untagged
       color $theme-color
+.search-result-list
+  li 
+    padding 15px 50px
 
 /* mobile style */
 @media only screen and (max-width: 768px)
@@ -67,3 +70,6 @@
       float none
     .post-title
       font-size remify(18px)
+  .search-result-list
+    li 
+      padding 10px 20px

--- a/source/js/search.js
+++ b/source/js/search.js
@@ -1,0 +1,85 @@
+var searchFunc = function(path, search_id, content_id) {
+  'use strict';
+  $.ajax({
+      url: path,
+      dataType: "xml",
+      success: function( xmlResponse ) {
+          // get the contents from search data
+          var datas = $( "entry", xmlResponse ).map(function() {
+              return {
+                  title: $( "title", this ).text(),
+                  content: $("content",this).text(),
+                  url: $( "url" , this).text()
+              };
+          }).get();
+          var $input = document.getElementById(search_id);
+          var $resultContent = document.getElementById(content_id);
+          $input.addEventListener('input', function(){
+              var str='<ul class=\"search-result-list\">';                
+              var keywords = this.value.trim().toLowerCase().split(/[\s\-]+/);
+              $resultContent.innerHTML = "";
+              if (this.value.trim().length <= 0) {
+                  return;
+              }
+              // perform local searching
+              datas.forEach(function(data) {
+                  var isMatch = true;
+                  var content_index = [];
+                  var data_title = data.title.trim().toLowerCase();
+                  var data_content = data.content.trim().replace(/<[^>]+>/g,"").toLowerCase();
+                  var data_url = data.url;
+                  var index_title = -1;
+                  var index_content = -1;
+                  var first_occur = -1;
+                  // only match artiles with not empty titles and contents
+                  if(data_title != '' && data_content != '') {
+                      keywords.forEach(function(keyword, i) {
+                          index_title = data_title.indexOf(keyword);
+                          index_content = data_content.indexOf(keyword);
+                          if( index_title < 0 && index_content < 0 ){
+                              isMatch = false;
+                          } else {
+                              if (index_content < 0) {
+                                  index_content = 0;
+                              }
+                              if (i == 0) {
+                                  first_occur = index_content;
+                              }
+                          }
+                      });
+                  }
+                  // show search results
+                  if (isMatch) {
+                      str += "<li><a href='"+ data_url +"' class='search-result-title'>"+ data_title +"</a>";
+                      var content = data.content.trim().replace(/<[^>]+>/g,"");
+                      if (first_occur >= 0) {
+                          // cut out 100 characters
+                          var start = first_occur - 20;
+                          var end = first_occur + 80;
+                          if(start < 0){
+                              start = 0;
+                          }
+                          if(start == 0){
+                              end = 100;
+                          }
+                          if(end > content.length){
+                              end = content.length;
+                          }
+                          var match_content = content.substr(start, end); 
+                          // highlight all keywords
+                          keywords.forEach(function(keyword){
+                              var regS = new RegExp(keyword, "gi");
+                              match_content = match_content.replace(regS, "<em class=\"search-keyword\">"+keyword+"</em>");
+                          });
+                          
+                          str += "<p class=\"search-result\">" + match_content +"...</p>"
+                      }
+                      str += "</li>";
+                  }
+              });
+              str += "</ul>";
+              $resultContent.innerHTML = str;
+          });
+      }
+  });
+}


### PR DESCRIPTION
站内搜索基于wzpan/hexo-generator-search对主题进行整合，本地实验已经整合成功，CSS样式如图
在使用时需要下载hexo-generator-search插件并将config内部的local_search中的enable改为true
The site search is based on wzpan/hexo-generator-search to integrate the theme, the local experiment has been integrated successfully, and the CSS style is shown in the figure.
If you want to use the site search, you need to download the "hexo-generator-search" plugin and change the "enable" in "local_search" inside the "config.yml" to true.
(刚开始第一次pull request时候有文件没上传，先前的已经关闭之后重新再PR的
![](https://user-images.githubusercontent.com/33247520/54136987-c6d1ea00-4457-11e9-86be-c0f79af16873.PNG)
